### PR TITLE
barcode with full sentence & movie reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 d3_visualizations/simple_nn_epoch_sorted.json
 /d3_visualizations/simple_nn_epoch_sorted.json
+d3_visualizations/hub.json
+d3_visualizations/ugh.json

--- a/d3_visualizations/barcode.html
+++ b/d3_visualizations/barcode.html
@@ -124,6 +124,12 @@
       d3.json("hub.json", function(largedataset) {
         dataSet = largedataset[epoch_val];
 
+        var max_sent = document.getElementById("num_sentences");
+        var ep_num = document.getElementById("epoch_slider");
+
+        max_sent.max = (Math.min(Object.keys(largedataset[0]).length -1), 300)
+        ep_num.max = Object.keys(largedataset).length -1;
+
         var i; 
         var test = [];
         for(i = 0; i <10; i++){
@@ -232,9 +238,6 @@
           w = d3.select(this)
             .select(".sent")
             .attr("id", "highlighted")
-
-          test = d3.selectAll("#highlighted")
-          console.log(test)
 
           bars = [...f[6]]
           changed_indicies = argsort(bars)

--- a/d3_visualizations/barcode.html
+++ b/d3_visualizations/barcode.html
@@ -15,18 +15,18 @@
       margin-bottom: 12px; /* Add some space below the input */
     }
 
-    .sent{
-      white-space: nowrap;
-    }
 
     .cosinesim{
       max-width:100%
     }
-    
-    table{
-      width: 100%;
-      display: inline-block;
+
+    .sent {
+      max-width: 1000px;
+      white-space: nowrap;
+      overflow: scroll;
+      text-overflow: ellipsis; 
     }
+
 
     #container{
       height: 150px;
@@ -43,14 +43,12 @@
     .center{
       text-align: center;
     }
-    .highlighted {  
+    #highlighted {  
       background-color: aqua;
+      white-space: normal;
       stroke-width: 1px;
       stroke: black;
-    }
-
-    td, th {
-      max-width:100%
+      overflow: visible;
     }
       
   </style>
@@ -61,7 +59,7 @@
     <div class="left">
       <h3> Epoch #:</h3>
       <h4 id="epochNum"></h4>
-      <input class="slider" id="epoch_slider" type="range" min="0" max="19" step="1" value="19" onchange="changedValues()"/>
+      <input class="slider" id="epoch_slider" type="range" min="0" max="19" step="1" value="0" onchange="changedValues()"/>
     </div>
     <div class="left">
       <h3> Number of Sentences:</h3>
@@ -101,7 +99,7 @@
       d3.selectAll("#epochNum").text(epoch_val);
       d3.selectAll("#sentNum").text(sentences_val);
 
-      d3.json("simple_nn_epoch_sorted.json", function(largedataset) {
+      d3.json("hub.json", function(largedataset) {
         dataSet = largedataset[epoch_val];
 
         d3.selectAll("table").remove();
@@ -123,8 +121,8 @@
       var sentences_val = d3.select("#num_sentences").property("value");
       d3.selectAll("#sentNum").text(sentences_val);
 
-      d3.json("simple_nn_epoch_sorted.json", function(largedataset) {
-        dataSet = largedataset[19];
+      d3.json("hub.json", function(largedataset) {
+        dataSet = largedataset[epoch_val];
 
         var i; 
         var test = [];
@@ -155,7 +153,7 @@
     }
 
     function createSVG(d) {
-      var w = 1;
+      var w = 3;
       var h = 20;
 
       var kpi = document.createElement("div");
@@ -176,7 +174,7 @@
           .attr({
           x: 0,
           y: 0, 
-          width: 1,
+          width: 3,
           height: 20
           })
           .style("opacity", .5  + d*10)
@@ -225,11 +223,18 @@
           .append(function(d) {
             return createSVG(d);
           });
-
+      
         tableBodyRows.on({
           "click": function(f){
-          d3.selectAll(".highlighted").classed("highlighted", false);
-          d3.select(this).classed("highlighted", true);
+          d3.selectAll("#highlighted")
+            .attr("id", null)
+            .classed("sent", true)
+          w = d3.select(this)
+            .select(".sent")
+            .attr("id", "highlighted")
+
+          test = d3.selectAll("#highlighted")
+          console.log(test)
 
           bars = [...f[6]]
           changed_indicies = argsort(bars)
@@ -257,9 +262,7 @@
             })
           
 
-          console.log("================================")
           tableBodyRows.each(function(k,l){
-            console.log(k)
             d3.select(this)
               .data(function(d){
                 test = [...k]


### PR DESCRIPTION
copied from slack:

Update on the barcode visualization, Owen gave me the json for the movie data and the sentences are quite large so I implemented some css on overflow. (I added an overflow scroll on them, but unsure if I like that but we can discuss). But i also updated clicking on a row so that if you click on a row it’ll be the comparison for the cosine similarity but it’ll also show the entire sentence as shown in this screenshot. Initially I did this with mouseover but I thought that was a little messy so I switched over to click event. I also bumped up the width for the barcodes from 1--> 3. And, now that there aren’t 1000 vectors everything runs a lot faster. Let me know any thoughts or anything.

screenshot also in slack, if you want the correct json file asj @OMarkley 

if you want to run it add the file sent in slack (hub_nn_epoch_sorted_for_thuyvy.json) and put it into the d3_visualizations folder and rename it to hub.json. Then run python -m http.server in ur terminal and navigate to barcode.html